### PR TITLE
Return empty set instead of throwing exception, so that property assertion generator works.

### DIFF
--- a/modules/owlapi/src/main/scala/org/geneontology/whelk/owlapi/WhelkOWLReasoner.scala
+++ b/modules/owlapi/src/main/scala/org/geneontology/whelk/owlapi/WhelkOWLReasoner.scala
@@ -98,7 +98,8 @@ class WhelkOWLReasoner(ontology: OWLOntology, bufferingMode: BufferingMode) exte
   }
 
   override def getDataPropertyValues(ind: OWLNamedIndividual, dp: OWLDataProperty): JSet[OWLLiteral] =
-    throw new UnsupportedOperationException("getDataPropertyValues")
+    //throw new UnsupportedOperationException("getDataPropertyValues")
+  Set.empty[OWLLiteral].asJava
 
   override def getReasonerName(): String = "Whelk"
 


### PR DESCRIPTION
This is a fix for https://github.com/ontodev/robot/issues/1121.